### PR TITLE
Downgraded react to v18 for monaco compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,10 +69,10 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.6.0",
-    "@types/react": "^19.0.8",
-    "@types/react-dom": "^19.0.3",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
     "monaco-editor": "^0.52.2",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }


### PR DESCRIPTION
Downgraded react to v18 for monaco compatibility and resolved the npm install error encountered below

```
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: co-debugger@0.0.1
npm error Found: react@19.0.0
npm error node_modules/react
npm error   react@"^19.0.0" from the root project
npm error
npm error Could not resolve dependency:
npm error peer react@"^16.8.0 || ^17.0.0 || ^18.0.0" from @monaco-editor/react@4.6.0
npm error node_modules/@monaco-editor/react
npm error   @monaco-editor/react@"^4.6.0" from the root project
npm error
npm error Fix the upstream dependency conflict, or retry
npm error this command with --force or --legacy-peer-deps
npm error to accept an incorrect (and potentially broken) dependency resolution.
npm error
npm error
npm error For a full report see:
```
Refs: https://github.com/suren-atoyan/monaco-react#readme
