### PR TITLE
Updated y-axis config to align the line number with code editor block

### DIFF
--- a/src/editor-webview/components/Timeline.tsx
+++ b/src/editor-webview/components/Timeline.tsx
@@ -302,6 +302,7 @@ export default function TimelineHighcharts({
         }
       },
       yAxis: {
+        ordinal: false,
         reversed: true,
         tickLength: 0,
         lineColor: "#999",
@@ -311,6 +312,8 @@ export default function TimelineHighcharts({
         plotBands: yPlotBands,
         min: startLine,
         max: endLine,
+        endOnTick: false,
+        startOnTick: false,
       },
       legend: { enabled: false },
 
@@ -324,8 +327,7 @@ export default function TimelineHighcharts({
       },
       credits: { enabled: false },
     };
-  }, [range, setRange, yPlotBands]);
-
+  }, [range, setRange, yPlotBands, startLine, endLine]);
 
   return (
     <div


### PR DESCRIPTION
@hank0982 I checked all the containers and wrappers but seemed like the height of those had all been set as 100% and I didn't find anything weird.

After double-checking the charts, I think the problem might be the height of each y-axis plot band is not fixed due to dynamic scaling.

![Screenshot 2025-02-24 at 9 02 12 PM](https://github.com/user-attachments/assets/f6978137-0cdb-4f2f-b9b2-6f9577042706)

The longer block with more lines of code tends to have shorter bands and the shorter block with fewer lines of code tends to have taller bands.

The way to disable dynamic scaling:

The `min` and `max` properties of the y-axis are set to **startLine** and **endLine**, respectively.
The `endOnTick` and `startOnTick` properties are set to **false** to ensure the axis does not automatically adjust to start or end on a tick.

After these changes, it's still not 100% perfect, but I'd say it's a bit better...

![Screenshot 2025-02-24 at 8 54 45 PM](https://github.com/user-attachments/assets/e71bf41f-53cf-4217-9b4c-de64180fb835)

Let me know what do you think.