### PR TITLE
feat: updated the logic that auto zoom in on the latest 10 data points

### DIFF
--- a/src/editor-webview/components/Timeline.tsx
+++ b/src/editor-webview/components/Timeline.tsx
@@ -236,6 +236,19 @@ export default function TimelineHighcharts({
       });
 
       chart.redraw(false); // Apply updates without full re-render
+
+      // Automatically zoom in on the latest 10 data points
+      const allTimestamps = Object.values(chartData)
+        .flat()
+        .map((d) => d.timestamp)
+        .sort((a, b) => a - b);
+      if (allTimestamps.length > 0) {
+        const totalPoints = allTimestamps.length;
+        const zoomStartIndex = Math.max(totalPoints - 10, 0);
+        const minTimestamp = allTimestamps[zoomStartIndex];
+        const maxTimestamp = allTimestamps[totalPoints - 1];
+        chart.xAxis[0].setExtremes(minTimestamp, maxTimestamp, true, false);
+      }
     }
   }, [chartData, selectedFunctions, isRuntimeContext, logMapping, functionKeys]);
 
@@ -351,7 +364,7 @@ export default function TimelineHighcharts({
       },
       credits: { enabled: false },
     };
-  }, [range, setRange, yPlotBands, startLine, endLine]);
+  }, [range, setRange, yPlotBands, startLine, endLine, chartData, logMapping]);
 
   return (
     <div


### PR DESCRIPTION
- Extract Timestamps:
Extract all timestamps from the chartData and sort them in ascending order.

- Calculate Extremes:
Determine the number of data points that correspond to the last 10 data points. Calculate the minimum and maximum timestamps for these data points.

- Set Extremes:
Use the setExtremes method of the xAxis to set the calculated minimum and maximum timestamps, effectively zooming in on the last 10 data points.
